### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,11 +7,11 @@ services:
     environment:
       WALTID_DATA_ROOT: ./data-root
       WALTID_WALLET_BACKEND_BIND_ADDRESS: 0.0.0.0
-      EXTERNAL_HOSTNAME: $HOSTNAME$COMPUTERNAME
+      EXTERNAL_HOSTNAME: $HOSTNAME
     volumes:
       - .:/waltid-wallet-backend/data-root # data store volume incl. config files.
     extra_hosts:
-      - "$HOSTNAME$COMPUTERNAME:host-gateway"
+      - "host.docker.internal:host-gateway"
   wallet-ui:
     image: waltid/ssikit-web-wallet:latest # wallet web ui docker image
   verifier-ui:


### PR DESCRIPTION
The configuration was tight to MS-Windows  and not generic for Linux and MacOs. The change to host.docker.internal:host-gateway works on Windows and MacOS